### PR TITLE
Fetch draft issues for preview mode only

### DIFF
--- a/lib/issues.ts
+++ b/lib/issues.ts
@@ -158,14 +158,18 @@ export function getAllIssuesMeta(issues: IssueAPIResponse[]) {
 
 const getAxiosRequest = <T>(url: string): Promise<T> => axios.get<T>(url).then(({ data }) => data);
 
+const getAdditionalIssueFilters = () => (process.env.IS_PREVIEW === 'true' ? '' : '&isDraft_eq=false');
+
 export const issueAPI = {
   allIssuesReversed: (): Promise<IssueAPIResponse[]> =>
     process.env.NODE_ENV === 'production'
-      ? getAxiosRequest<IssueAPIResponse[]>(`${process.env.CMS_API}issues?_sort=id:DESC`)
+      ? getAxiosRequest<IssueAPIResponse[]>(`${process.env.CMS_API}issues?_sort=id:DESC${getAdditionalIssueFilters()}`)
       : getReversedSampleIssues(5),
   limitedIssuesReversed: (limit = 3): Promise<IssueAPIResponse[]> =>
     process.env.NODE_ENV === 'production'
-      ? getAxiosRequest<IssueAPIResponse[]>(`${process.env.CMS_API}issues?_sort=id:DESC&_limit=${limit}`)
+      ? getAxiosRequest<IssueAPIResponse[]>(
+          `${process.env.CMS_API}issues?_sort=id:DESC&_limit=${limit}${getAdditionalIssueFilters()}`
+        )
       : getReversedSampleIssues(limit),
   getIssue: (id: number): Promise<IssueAPIResponse> =>
     process.env.NODE_ENV === 'production'

--- a/pages/issues/[id].tsx
+++ b/pages/issues/[id].tsx
@@ -42,6 +42,10 @@ export default function IssueComponent({ issueData }: { issueData: Issue }): JSX
     }
   }, [router.isReady]);
 
+  if (router.isFallback) {
+    return <></>;
+  }
+
   return (
     <Layout
       title={`#${issueData.meta.number} | ${issueData.meta.title} | ${siteConfig.name}`}
@@ -117,12 +121,19 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const id: number = (params.id as unknown) as number;
-  const data = await issueAPI.getIssue(id);
-  const issueData = mapToIssue(data);
-  return {
-    props: {
-      issueData,
-    },
-    revalidate: 180,
-  };
+  try {
+    const data = await issueAPI.getIssue(id);
+    const issueData = mapToIssue(data);
+    return {
+      props: {
+        issueData,
+      },
+      revalidate: 180,
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      notFound: true,
+    };
+  }
 };

--- a/pages/issues/[id].tsx
+++ b/pages/issues/[id].tsx
@@ -111,7 +111,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
   return {
     paths,
-    fallback: false,
+    fallback: true,
   };
 };
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
+Disallow:
 Sitemap: https://scriptified.dev/sitemap.xml

--- a/styles/global.css
+++ b/styles/global.css
@@ -168,6 +168,10 @@ body {
 /*
 * Styles for react markdown
 */
+.react-markdown {
+  white-space: pre-wrap;
+}
+
 .react-markdown a {
   text-decoration: underline;
 }


### PR DESCRIPTION
- :sparkles: Fetch draft issues for preview mode only
- :bug: Fixed a bug that showed 404 for issues pages generated via ISR because of [fallback being `false`](https://nextjs.org/docs/basic-features/data-fetching#fallback-false)
- 💄 Preserve white spaces in react-markdown